### PR TITLE
Optimize data pipeline and dashboards

### DIFF
--- a/socioeco_dash_json/app/app.py
+++ b/socioeco_dash_json/app/app.py
@@ -1,6 +1,7 @@
 
 import os
 import json
+from typing import Iterable, Any, Optional
 import pandas as pd
 from dash import Dash, dcc, html, Input, Output
 import plotly.express as px
@@ -9,9 +10,9 @@ import sqlite3
 DB_PATH = os.environ.get("DB_PATH", "data/socioeco.db")
 COMPOSITES_JSON = os.environ.get("COMPOSITES_JSON", "config/composites.json")
 
-def read_table(query: str) -> pd.DataFrame:
+def read_table(query: str, params: Optional[Iterable[Any]] = None) -> pd.DataFrame:
     conn = sqlite3.connect(DB_PATH)
-    df = pd.read_sql_query(query, conn)
+    df = pd.read_sql_query(query, conn, params=params)
     conn.close()
     return df
 
@@ -76,13 +77,14 @@ app.layout = html.Div([
 def update_component_graph(code, selected_countries):
     if code is None or not selected_countries:
         return px.line()
-    in_clause = ",".join([f"'{c}'" for c in selected_countries])
+    placeholders = ",".join("?" for _ in selected_countries)
     q = f"""
         SELECT country, date, value FROM raw_values
-        WHERE code = '{code.replace("'", "''")}' AND country IN ({in_clause})
+        WHERE code = ? AND country IN ({placeholders})
         ORDER BY date
     """
-    df = read_table(q)
+    params = [code] + list(selected_countries)
+    df = read_table(q, params)
     fig = px.line(df, x="date", y="value", color="country", markers=True, title=code_to_name.get(code, code))
     return fig
 
@@ -94,14 +96,15 @@ def update_component_graph(code, selected_countries):
 def update_composite_graph(comp_name, selected_countries):
     if comp_name is None or not selected_countries:
         return px.line()
-    in_clause = ",".join([f"'{c}'" for c in selected_countries])
+    placeholders = ",".join("?" for _ in selected_countries)
     q = f"""
         SELECT country, date, value FROM composite_values
-        WHERE composite = '{comp_name.replace("'", "''")}'
-          AND country IN ({in_clause})
+        WHERE composite = ?
+          AND country IN ({placeholders})
         ORDER BY date
     """
-    df = read_table(q)
+    params = [comp_name] + list(selected_countries)
+    df = read_table(q, params)
     fig = px.line(df, x="date", y="value", color="country", markers=True, title=comp_name)
     return fig
 

--- a/socioeco_dash_json/etl/compute.py
+++ b/socioeco_dash_json/etl/compute.py
@@ -7,7 +7,6 @@ from .normalize import min_max_normalize
 
 def compute_composites(db_path: str="data/socioeco.db", composites_json: str="config/composites.json") -> None:
     conn = get_conn(db_path)
-    raw = pd.read_sql_query("SELECT country, date, code, value FROM raw_values", conn)
     with open(composites_json, "r") as f:
         comps: Dict[str, Any] = json.load(f)
 
@@ -17,7 +16,12 @@ def compute_composites(db_path: str="data/socioeco.db", composites_json: str="co
         if not components:
             continue
         codes = [c["code"] for c in components]
-        sub = raw[raw["code"].isin(codes)].copy()
+        placeholders = ",".join("?" for _ in codes)
+        sub = pd.read_sql_query(
+            f"SELECT country, date, code, value FROM raw_values WHERE code IN ({placeholders})",
+            conn,
+            params=codes,
+        )
         if sub.empty:
             continue
         frames = []

--- a/socioeco_dash_json/etl/db.py
+++ b/socioeco_dash_json/etl/db.py
@@ -35,26 +35,39 @@ def init_db(conn: sqlite3.Connection) -> None:
 
 def upsert_raw(conn: sqlite3.Connection, rows: Iterable[Dict[str, Any]]) -> int:
     cur = conn.cursor()
-    count = 0
-    for r in rows:
-        cur.execute(
-            "INSERT OR REPLACE INTO raw_values(country,country_name,code,indicator_name,date,value) "
-            "VALUES (?,?,?,?,?,?)",
-            (r.get("country"), r.get("country_name"), r.get("code"), r.get("indicator_name"), r.get("date"), r.get("value"))
+    data = [
+        (
+            r.get("country"),
+            r.get("country_name"),
+            r.get("code"),
+            r.get("indicator_name"),
+            r.get("date"),
+            r.get("value"),
         )
-        count += 1
+        for r in rows
+    ]
+    if not data:
+        return 0
+    cur.executemany(
+        "INSERT OR REPLACE INTO raw_values(country,country_name,code,indicator_name,date,value) "
+        "VALUES (?,?,?,?,?,?)",
+        data,
+    )
     conn.commit()
-    return count
+    return len(data)
 
 def upsert_composite(conn: sqlite3.Connection, rows: Iterable[Dict[str, Any]]) -> int:
     cur = conn.cursor()
-    count = 0
-    for r in rows:
-        cur.execute(
-            "INSERT OR REPLACE INTO composite_values(country, composite, date, value) "
-            "VALUES (?,?,?,?)",
-            (r.get("country"), r.get("composite"), r.get("date"), r.get("value"))
-        )
-        count += 1
+    data = [
+        (r.get("country"), r.get("composite"), r.get("date"), r.get("value"))
+        for r in rows
+    ]
+    if not data:
+        return 0
+    cur.executemany(
+        "INSERT OR REPLACE INTO composite_values(country, composite, date, value) "
+        "VALUES (?,?,?,?)",
+        data,
+    )
     conn.commit()
-    return count
+    return len(data)

--- a/socioeco_dash_json/etl/worldbank.py
+++ b/socioeco_dash_json/etl/worldbank.py
@@ -1,45 +1,56 @@
 
 import time
+from concurrent.futures import ThreadPoolExecutor
 import requests
 import pandas as pd
 from typing import List
 
 WDI_BASE = "https://api.worldbank.org/v2"
 
-def fetch_indicator(countries: List[str], indicator: str, start: int=2000, end: int=2024, sleep=0.1) -> pd.DataFrame:
-    dfs = []
+def fetch_indicator(countries: List[str], indicator: str, start: int = 2000, end: int = 2024, sleep: float = 0.0) -> pd.DataFrame:
+    dfs: List[dict] = []
     per_page = 20000
-    for c in countries:
-        url = f"{WDI_BASE}/country/{c}/indicator/{indicator}?format=json&per_page={per_page}&date={start}:{end}"
-        r = requests.get(url, timeout=30)
-        r.raise_for_status()
-        js = r.json()
-        if not isinstance(js, list) or len(js) < 2:
-            continue
-        rows = js[1] or []
-        for row in rows:
-            val = row.get("value")
-            date = row.get("date")
-            ind_name = (row.get("indicator") or {}).get("value")
-            if date is None:
+    with requests.Session() as session:
+        for c in countries:
+            url = f"{WDI_BASE}/country/{c}/indicator/{indicator}?format=json&per_page={per_page}&date={start}:{end}"
+            r = session.get(url, timeout=30)
+            r.raise_for_status()
+            js = r.json()
+            if not isinstance(js, list) or len(js) < 2:
                 continue
-            dfs.append({
-                "country": (row.get("country") or {}).get("id"),
-                "country_name": (row.get("country") or {}).get("value"),
-                "code": indicator,
-                "indicator_name": ind_name,
-                "date": int(date),
-                "value": None if val is None else float(val),
-            })
-        time.sleep(sleep)
+            rows = js[1] or []
+            for row in rows:
+                val = row.get("value")
+                date = row.get("date")
+                ind_name = (row.get("indicator") or {}).get("value")
+                if date is None:
+                    continue
+                dfs.append(
+                    {
+                        "country": (row.get("country") or {}).get("id"),
+                        "country_name": (row.get("country") or {}).get("value"),
+                        "code": indicator,
+                        "indicator_name": ind_name,
+                        "date": int(date),
+                        "value": None if val is None else float(val),
+                    }
+                )
+            if sleep:
+                time.sleep(sleep)
     if not dfs:
         return pd.DataFrame(columns=["country","country_name","code","indicator_name","date","value"])
     return pd.DataFrame(dfs)
 
-def fetch_many(countries: List[str], indicators: List[str], start: int=2000, end: int=2024) -> pd.DataFrame:
-    frames = []
-    for ind in indicators:
-        frames.append(fetch_indicator(countries, ind, start=start, end=end))
+def fetch_many(countries: List[str], indicators: List[str], start: int = 2000, end: int = 2024) -> pd.DataFrame:
+    if not indicators:
+        return pd.DataFrame(columns=["country","country_name","code","indicator_name","date","value"])
+    max_workers = min(8, len(indicators)) or 1
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [
+            executor.submit(fetch_indicator, countries, ind, start, end)
+            for ind in indicators
+        ]
+    frames = [f.result() for f in futures if not f.result().empty]
     if not frames:
         return pd.DataFrame(columns=["country","country_name","code","indicator_name","date","value"])
     return pd.concat(frames, ignore_index=True)


### PR DESCRIPTION
## Summary
- Batch insert ETL data using `executemany`
- Parameterize SQL queries in Dash app to avoid injection and handle dynamic lists
- Compute composites per indicator subset to reduce memory usage
- Speed up World Bank extraction with concurrent requests

## Testing
- `python -m py_compile socioeco_dash_json/app/app.py socioeco_dash_json/etl/compute.py socioeco_dash_json/etl/db.py socioeco_dash_json/etl/normalize.py socioeco_dash_json/etl/run_etl.py socioeco_dash_json/etl/worldbank.py`


------
https://chatgpt.com/codex/tasks/task_e_689fe597def483308b259a50f570fdc7